### PR TITLE
fixed a scoring issue, mouse hidden during game

### DIFF
--- a/prototype3/P3/Assets/Scenes/Boi Scene.unity
+++ b/prototype3/P3/Assets/Scenes/Boi Scene.unity
@@ -146,7 +146,7 @@ MonoBehaviour:
   itemsCollected: 0
   bestTimesPerSpeed: 1b0000002d0000004b00000078000000a5000000d2000000
   baseScore: 5000
-  timePenalty: 189
+  timePenalty: 123
   scoreBonus: 1.25
 --- !u!4 &741592338
 Transform:

--- a/prototype3/P3/Assets/Scripts/NextScene.cs
+++ b/prototype3/P3/Assets/Scripts/NextScene.cs
@@ -15,6 +15,11 @@ public class NextScene : MonoBehaviour
     public GameObject lines;
     public GameObject title;
 
+	public void Awake()
+	{
+		Cursor.visible = false;
+	}
+	
     public void GoToNextScene()
     {
         if (willQuitTheGame)

--- a/prototype3/P3/Assets/Scripts/ScoreBoi.cs
+++ b/prototype3/P3/Assets/Scripts/ScoreBoi.cs
@@ -79,7 +79,7 @@ public class ScoreBoi : MonoBehaviour
             timeElapsed += Time.deltaTime;
 
             seconds = Mathf.FloorToInt(timeElapsed);
-            totalSeconds = seconds;
+            totalSeconds += seconds;
 
             if (seconds == 60)
             {


### PR DESCRIPTION
- Fixed an issue where the player always received the highest possible score at their max speed channel. 
- Mouse cursor is now set to invisible on game start

Please review. And then shake your head at my nonsense